### PR TITLE
Added note for g++ fix in installation manual

### DIFF
--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -50,6 +50,12 @@ If they're not available already, common prerequisites can be installed directly
    sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev
 
 The packages are required by many of the packages installed later.
+
+.. NOTE::
+
+   In some cases, if using Ubuntu 20.04 LTS, ``g++`` might not be included in the set of packages listed above.
+   In case your builds error out because they cannot locate ``c++`` compilers, use ``sudo apt install build-essential``. 
+   
 On a cluster, check the output of ``module avail`` to see what has already been installed.
 They can also be installed locally, but they are common enough that they are typically pre-installed.
 

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -47,15 +47,10 @@ Common Prerequisites
 --------------------
 If they're not available already, common prerequisites can be installed directly from a Debian repository::
 
-   sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev
+   sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev build-essential
 
 The packages are required by many of the packages installed later.
 
-.. NOTE::
-
-   In some cases, if using Ubuntu 20.04 LTS, ``g++`` might not be included in the set of packages listed above.
-   In case your builds error out because they cannot locate ``c++`` compilers, use ``sudo apt install build-essential``. 
-   
 On a cluster, check the output of ``module avail`` to see what has already been installed.
 They can also be installed locally, but they are common enough that they are typically pre-installed.
 


### PR DESCRIPTION
## Purpose
As for title, I added a note that recommends to install `build-essentials` if `g++` is not installed together with the other listed packages. This issue happened only in the latest build-from-scratch I performed - did not happen on a previous build of Ubuntu 20.04 on my shuttle box.

## Type of change

- Documentation update

## Checklist

- [x] I have built the documentation locally on my machine
