### PR TITLE
added adjoint check and fixed mkdir for output folder

### DIFF
--- a/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
+++ b/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
@@ -39,7 +39,7 @@ outputDirectory = "output"
 if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
 else:
-    raise Warning("The directory already exists! Please delete it or provide a new path")
+    raise OSError("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up

--- a/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
+++ b/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
@@ -36,7 +36,7 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=nGroup, memberSizes=nProcPerGroup)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0:
+if comm.rank == 0 and os.path.exists(outputDirectory) is False:
     os.mkdir(outputDirectory)
 # rst multipoint (end)
 # ======================================================================
@@ -212,6 +212,7 @@ def cruiseFuncsSens(x, funcs):
     for i in range(nFlowCases):
         if i % nGroup == ptID:
             CFDSolver.evalFunctionsSens(aeroProblems[i], funcsSens)
+            CFDSolver.checkAdjointFailure(aeroProblems[i], funcsSens)
     if MPI.COMM_WORLD.rank == 0:
         print(funcsSens)
     return funcsSens

--- a/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
+++ b/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
@@ -36,8 +36,10 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=nGroup, memberSizes=nProcPerGroup)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0 and os.path.exists(outputDirectory) is False:
+if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
+else:
+    raise Warning("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up

--- a/tutorial/airfoilopt/singlepoint/airfoil_opt.py
+++ b/tutorial/airfoilopt/singlepoint/airfoil_opt.py
@@ -37,7 +37,7 @@ outputDirectory = "output"
 if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
 else:
-    raise Warning("The directory already exists! Please delete it or provide a new path")
+    raise OSError("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up

--- a/tutorial/airfoilopt/singlepoint/airfoil_opt.py
+++ b/tutorial/airfoilopt/singlepoint/airfoil_opt.py
@@ -34,8 +34,10 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=1, memberSizes=MPI.COMM_WORLD.size)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0 and os.path.exists(outputDirectory) is False:
+if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
+else:
+    raise Warning("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up

--- a/tutorial/airfoilopt/singlepoint/airfoil_opt.py
+++ b/tutorial/airfoilopt/singlepoint/airfoil_opt.py
@@ -34,7 +34,7 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=1, memberSizes=MPI.COMM_WORLD.size)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0:
+if comm.rank == 0 and os.path.exists(outputDirectory) is False:
     os.mkdir(outputDirectory)
 # rst multipoint (end)
 # ======================================================================
@@ -191,6 +191,7 @@ def cruiseFuncsSens(x, funcs):
     funcsSens = {}
     DVCon.evalFunctionsSens(funcsSens)
     CFDSolver.evalFunctionsSens(ap, funcsSens)
+    CFDSolver.checkAdjointFailure(ap, funcsSens)
     if MPI.COMM_WORLD.rank == 0:
         print(funcsSens)
     return funcsSens

--- a/tutorial/opt/aero/aero_opt.py
+++ b/tutorial/opt/aero/aero_opt.py
@@ -23,7 +23,7 @@ outputDirectory = "output"
 if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
 else:
-    raise Warning("The directory already exists! Please delete it or provide a new path")
+    raise OSError("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up

--- a/tutorial/opt/aero/aero_opt.py
+++ b/tutorial/opt/aero/aero_opt.py
@@ -20,7 +20,7 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=1, memberSizes=MPI.COMM_WORLD.size)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0:
+if comm.rank == 0 and os.path.exists(outputDirectory) is False:
     os.mkdir(outputDirectory)
 # rst multipoint (end)
 # ======================================================================
@@ -156,6 +156,7 @@ def cruiseFuncsSens(x, funcs):
     funcsSens = {}
     DVCon.evalFunctionsSens(funcsSens)
     CFDSolver.evalFunctionsSens(ap, funcsSens)
+    CFDSolver.checkAdjointFailure(ap, funcsSens)
     if comm.rank == 0:
         print(funcsSens)
     return funcsSens

--- a/tutorial/opt/aero/aero_opt.py
+++ b/tutorial/opt/aero/aero_opt.py
@@ -20,8 +20,10 @@ MP = multiPointSparse(MPI.COMM_WORLD)
 MP.addProcessorSet("cruise", nMembers=1, memberSizes=MPI.COMM_WORLD.size)
 comm, setComm, setFlags, groupFlags, ptID = MP.createCommunicators()
 outputDirectory = "output"
-if comm.rank == 0 and os.path.exists(outputDirectory) is False:
+if not os.path.exists(outputDirectory):
     os.mkdir(outputDirectory)
+else:
+    raise Warning("The directory already exists! Please delete it or provide a new path")
 # rst multipoint (end)
 # ======================================================================
 #         ADflow Set-up


### PR DESCRIPTION
## Purpose
I added `checkAdjointFailure()`, so to close #3 
I also took the chance to add an additional check before we build the output directory, so to be sure that the runscript does not freeze if such folder already exists.

## Type of change

- New feature (non-breaking change which adds functionality)
- Maintenance

## Testing
- The script does not freeze if the `output` folder already exists
- now a `'fail'` key is appended to the `funcSens` dictionary, to include in the dict whether the adjoint solver has converged or not.

## Checklist
- [x] I tested the changes locally
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
