### PR TITLE
Updated pyHyp fileType

### DIFF
--- a/tutorial/aero/meshing/volume/run_pyhyp.py
+++ b/tutorial/aero/meshing/volume/run_pyhyp.py
@@ -7,7 +7,7 @@ options = {
     #   General options
     # ---------------------------
     "inputFile": "wing.cgns",
-    "fileType": "cgns",
+    "fileType": "CGNS",
     "unattachedEdgesAreSymmetry": True,
     "outerFaceBC": "farfield",
     "autoConnect": True,


### PR DESCRIPTION
## Purpose
The pyHyp update [here](https://github.com/mdolab/pyhyp/pull/38) changed the case of the `fileType` strings. I updated the pyHyp script in the wing tutorial accordingly. The airfoil script relies on the default (`PLOT3D`), so it does not need to be changed.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Maintenance update

## Testing
I ran the script with pyHyp v2.3.2.