### PR TITLE
Small corrections to third party install instructions

### DIFF
--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -269,7 +269,7 @@ Download and unpack the source directory, from your packages directory:
 .. code-block:: bash
 
    cd $HOME/packages
-   wget https://github.com/CGNS/CGNS/archive/<version>.tar.gz
+   wget https://github.com/CGNS/CGNS/archive/v<version>.tar.gz
    tar -xvaf <version>.tar.gz
    cd CGNS-<version>
 
@@ -391,7 +391,7 @@ It is installed with::
 
 On a ``conda``-based system, it is recommended to use ``conda`` to install numpy and scipy::
 
-   conda install numpy==<version>
+   conda install numpy=<version>
 
 SciPy
 ~~~~~
@@ -402,7 +402,7 @@ It is installed with::
 
 On a ``conda``-based system, it is recommended to use ``conda`` to install numpy and scipy::
 
-   conda install scipy==<version>
+   conda install scipy=<version>
 
 .. note::
    On a cluster, most likely numpy and scipy will already be


### PR DESCRIPTION
## Purpose
Made two small corrections to third party installation docs:
- Version specification for installing with conda uses only one `=` instead of two
- CGNS source directory URL has a 'v' before the version number

## Type of change
What types of change is it?

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
