### PR TITLE
Update SWIG installation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -10,10 +10,17 @@ project = "MACH-Aero Documentation"
 extensions.extend(["sphinxcontrib.bibtex"])
 
 # Specify the baseurls for the projects I want to link to
-intersphinx_mapping = {
-    "pyoptsparse": ("https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest", None),
-    "pygeo": ("https://mdolab-pygeo.readthedocs-hosted.com/en/latest", None),
-}
+repos = [
+    "pygeo",
+    "pyoptsparse",
+    "baseclasses",
+    "idwarp",
+    "adflow",
+    "pyhyp",
+    "multipoint",
+    "pyspline",
+]
+intersphinx_mapping = {r: (f"https://mdolab-{r}.readthedocs-hosted.com/en/latest", None) for r in repos}
 
 # bibtex
 bibtex_bibfiles = ["machFramework/references.bib"]

--- a/index.rst
+++ b/index.rst
@@ -5,17 +5,17 @@ MACH-Aero Framework
 MACH-Aero is a framework for performing gradient-based aerodynamic shape optimization.
 It consists of the following core modules:
 
-- `baseClasses <https://mdolab-baseclasses.readthedocs-hosted.com>`_ defines Python classes used by the other packages
-- `pySpline <https://mdolab-pyspline.readthedocs-hosted.com>`_ is a B-spline implementation used by the other packages
-- `pyGeo <https://mdolab-pygeo.readthedocs-hosted.com>`_ is a module for geometry manipulation and constraint formulation
-- `IDWarp <https://mdolab-idwarp.readthedocs-hosted.com>`_ performs mesh warping using an inverse distance method
-- `ADflow <https://mdolab-adflow.readthedocs-hosted.com>`_ is a 2nd-order finite volume CFD solver with an efficient adjoint implementation
-- `pyOptSparse <https://mdolab-pyoptsparse.readthedocs-hosted.com>`_ is an optimization framework which provides a unified interface to several popular optimizers
+- :doc:`baseClasses <baseclasses:index>` defines Python classes used by the other packages
+- :doc:`pySpline <pyspline:index>` is a B-spline implementation used by the other packages
+- :doc:`pyGeo <pygeo:index>` is a module for geometry manipulation and constraint formulation
+- :doc:`IDWarp <idwarp:index>` performs mesh warping using an inverse distance method
+- :doc:`ADflow <adflow:index>` is a 2nd-order finite volume CFD solver with an efficient adjoint implementation
+- :doc:`pyOptSparse <pyoptsparse:index>` is an optimization framework which provides a unified interface to several popular optimizers
 
 And the following optional modules:
 
-- `pyHyp <https://mdolab-pyhyp.readthedocs-hosted.com>`_ is a hyperbolic mesh generation tool used as a preprocessing step
-- `multiPoint <https://mdolab-multipoint.readthedocs-hosted.com>`_ facilitates distributed multipoint optimization and handles the parallel communication using MPI
+- :doc:`pyHyp <pyhyp:index>` is a hyperbolic mesh generation tool used as a preprocessing step
+- :doc:`multiPoint <multipoint:index>` facilitates distributed multipoint optimization and handles the parallel communication using MPI
 - `cgnsUtilities <https://github.com/mdolab/cgnsutilities>`_ is a command-line tool that allows carrying out several simple mesh manipulation operations on CGNS grids
 - `DAFoam <https://dafoam.github.io/>`_ provides efficient adjoint implementations for OpenFOAM to be used for CFD instead of ADflow
 

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -37,7 +37,6 @@ CGNS      3.3.0   4.1.2
 Python    3.7     3.8
 NumPy     1.16    1.18
 SciPy     1.2     1.4
-swig      2.0.12  2.0.12
 ========= ======= =======
 
 The supported operating systems are Ubuntu 18.04 and 20.04, together with GNU compiler versions 7 to 9.
@@ -49,7 +48,7 @@ Common Prerequisites
 --------------------
 If they're not available already, common prerequisites can be installed directly from a Debian repository::
 
-   sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev build-essential
+   sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev build-essential swig
 
 The packages are required by many of the packages installed later.
 
@@ -322,45 +321,6 @@ Note that the version of these libraries might be different on your machine ::
 If you compiled with ``--enable-cgnstools`` you either need to add the binary path to your PATH environmental variable or you can install the binaries system wide.
 By specifying the installation prefix as shown in the example configure commands above, the binary path is in your PATH environmental variables;
 without specifying the prefix, the default is a system path, which requires sudo.
-
-.. _install_swig:
-
-SWIG (optional)
-~~~~~~~~~~~~~~~
-
-SWIG is a wrapper for external software written in C or C++. It is an **OPTIONAL** component for MACH-Aero, as it is required by only some of its sub-modules (e.g. NSGA2 and NOMAD optimizers used by pyOptSparse, as discussed `here <https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/install.html>`_).
-
-.. WARNING::
-
-   SWIG 2.0.12 is the **ONLY** currently supported version. Other versions are not recommended and are installed at your own risk.
-
-Download and unpack the source files, from your packages directory:
-
-.. code-block:: bash
-
-   cd $HOME/packages
-   wget http://prdownloads.sourceforge.net/swig/swig-2.0.12.tar.gz
-   tar -xzf swig-2.0.12.tar.gz
-   cd ./swig-2.0.12
-
-Configure your environment variables by adding the following lines to your ``.bashrc`` file, remembering to ``source ~/.bashrc`` or opening a new terminal once you saved the changes:
-
-.. code-block:: bash
-
-   export SWIG_HOME=$HOME/packages/swig-2.0.12
-   export PATH=$PATH:$SWIG_HOME/bin
-
-Then configure SWIG and build the binaries using the following commands:
-
-.. code-block:: bash
-
-   ./configure --prefix=$SWIG_HOME
-   make
-   make install
-
-.. NOTE::
-
-   The configuration and build of SWIG requires the `PCRE developer package <https://www.pcre.org/>`_. If not already present on your system, you can install it via ``sudo apt-get install libpcre3 libpcre3-dev``
 
 Python Packages
 ---------------

--- a/machAeroTutorials/aero_adflow.rst
+++ b/machAeroTutorials/aero_adflow.rst
@@ -9,7 +9,7 @@ Introduction
 There is no graphical user interface for ADflow.
 The cases are prepared with python scripts and run from the command line.
 In this section of the tutorial, we will explain the nuts and bolts of a basic ADflow runscript.
-You will find a complete introduction to ADflow in the `docs <https://mdolab-adflow.readthedocs-hosted.com/en/latest/introduction.html>`_ .
+You will find a complete introduction to ADflow in the :doc:`docs <adflow:introduction>`.
 
 Files
 =====
@@ -36,7 +36,7 @@ Import libraries
    :end-before: # rst ADflow options
 
 First we import ADflow.
-We also need to import `baseclasses <https://github.com/mdolab/baseclasses>`_, which is a library of problem and solver classes used to encourage a common API within the MACH suite.
+We also need to import ``baseclasses``, which is a library of problem and solver classes used to encourage a common API within the MACH suite.
 In this case we will be using the AeroProblem, which is a container for the flow conditions that we want to analyze.
 Finally, it is convenient to import the mpi4py library to prevent printing multiple times if we are running on multiple processors.
 Importing mpi4py is not entirely necessary in the runscript because ADflow does it internally if necessary.
@@ -53,7 +53,7 @@ The `I/O Parameters` include the mesh file, the output directory, and the variab
 Under `Solver Parameters`, you can choose a basic solver (DADI or Runge Kutta) and set the CFL and multigrid parameters.
 Additionally, the Approximate Newton-Krylov (ANK) and Newton-Krylov (NK) solvers can be used to speed up convergence of the solver.
 Finally, we can terminate the solver based on relative convergence of the norm of the residuals or maximum number of iterations.
-We strongly recommend going over the descriptions and tips on solvers and solver options in the ADflow `solvers docs <https://mdolab-adflow.readthedocs-hosted.com/en/latest/solvers.html>`_.
+We strongly recommend going over the descriptions and tips on solvers and solver options in the ADflow :doc:`solvers docs <adflow:solvers>`.
 
 Create solver
 -------------

--- a/machAeroTutorials/aero_adflow_polar.rst
+++ b/machAeroTutorials/aero_adflow_polar.rst
@@ -39,7 +39,7 @@ Import libraries
    :end-before: # rst ADflow options
 
 As in the previous example, we first import ADflow.
-We also need to import `baseclasses <https://github.com/mdolab/baseclasses>`_, which is a library of problem and solver classes used to encourage a common API within the MACH suite.
+We also need to import :doc:`baseclasses <baseclasses:index>`, which is a library of problem and solver classes used to encourage a common API within the MACH suite.
 We will again be using the AeroProblem, which is a container for the flow conditions that we want to analyze.
 However, in this case we will sequentially update the alpha parameter to produce the desired drag polar.
 Again, it is convenient to import the mpi4py library to prevent printing multiple times if we are running on multiple processors.
@@ -51,7 +51,7 @@ ADflow options
    :start-after: # rst ADflow options
    :end-before: # rst Start ADflow
 
-An exhaustive list of the ADflow options and their descriptions can be found in the `docs <https://mdolab-adflow.readthedocs-hosted.com/en/latest/options.html>`_.
+An exhaustive list of the ADflow options and their descriptions can be found in :doc:`ADflow options<adflow:options>`.
 We will not go over every option here, as they are outlined in the previous example.
 However, we will highlight the option that has been changed for this case.
 This option is the "infchangecorrection" option.

--- a/machAeroTutorials/aero_overview.rst
+++ b/machAeroTutorials/aero_overview.rst
@@ -3,7 +3,7 @@
 ####################
 Aerodynamic Analysis
 ####################
-High-fidelity aerodynamic analysis in the MDOlab is done using `ADflow <https://github.com/mdolab/adflow>`_.
+High-fidelity aerodynamic analysis in the MDOlab is done using :doc:`ADflow <adflow:index>`.
 ADflow is a finite-volume CFD solver for cell-centered multiblock and overset meshes.
 ADflow solves the compressible Euler, laminar Navier--Stokes, and RANS equations with a second-order accurate spatial discretization.
 More information on ADflow can be found somewhere (needs link).

--- a/machAeroTutorials/aero_pygeo.rst
+++ b/machAeroTutorials/aero_pygeo.rst
@@ -11,7 +11,7 @@ The native geometry file type for ICEM (our meshing software of choice) is a ".t
 You can use any CAD software to generate an ".igs" file and then convert the ".igs" file to a ".tin" file with ICEM or pyGeo.
 However, this tutorial will teach you how to generate a wing surface from airfoil data using pyGeo.
 pyGeo is set up to loft a surface between a set of airfoils distributed along the span of the wing.
-For more details on the options in pyGeo see the `docs <https://mdolab-pygeo.readthedocs-hosted.com/>`_.
+For more details on the options in pyGeo see the :doc:`docs <pygeo:index>`.
 
 Files
 =====
@@ -84,7 +84,7 @@ Call pyGeo
     :start-after: # rst Run pyGeo
     :end-before: # rst Write output files
 
-A detailed explanation of each argument is available in the `pyGeo docs <https://mdolab-pygeo.readthedocs-hosted.com/en/latest/pyGeo.html>`_.
+A detailed explanation of each argument is available in the :doc:`pyGeo docs <pygeo:pyGeo>`.
 The final four options stipulate a rounded wingtip and a blunt trailing edge with a square tip (i.e., a square face at the trailing edge instead of a rounded face) and a thickness of 0.25 inches.
 
 Write output files

--- a/machAeroTutorials/aero_pyhyp.rst
+++ b/machAeroTutorials/aero_pyhyp.rst
@@ -9,7 +9,7 @@ Introduction
 The objective of this section is to create a volume mesh using pyHyp.
 The surface mesh serves as the seed for hyperbolically marching the mesh to the farfield.
 Generating the volume mesh in this way is fast, repeatable, and results in a high-quality mesh.
-More details on pyHyp can be found in the `pyHyp documentation <https://mdolab-pyhyp.readthedocs-hosted.com>`__ or in the code itself.
+More details on pyHyp can be found in the :doc:`pyHyp documentation <pyhyp:index>` or in the code itself.
 
 Files
 =====
@@ -39,7 +39,7 @@ This is the standard way of importing the pyHyp library.
 Options
 -------
 For each module in MACH, we generally pass in options using a dictionary.
-A complete list of definitions of the pyHyp options can be found in the `pyHyp documentation on plot3d usage <https://mdolab-pyhyp.readthedocs-hosted.com/en/latest/usage.html#usage-with-plot3d-files>`_.
+A complete list of definitions of the pyHyp options can be found in the :doc:`pyHyp documentation <pyhyp:options>`.
 Here we will point a few of the more basic options.
 For pyHyp, the options can be organized like so:
 
@@ -83,7 +83,7 @@ Grid parameters:
         Distance of the far-field.
 
 The following options are related to the algorithms that are used to generate the mesh and usually these default values do not need to be modified.
-More information can be found in the `pyHyp documentation <https://mdolab-pyhyp.readthedocs-hosted.com/>`__.
+More information can be found in the :doc:`pyHyp documentation <pyhyp:index>`.
 For example, ``epsE`` may be of interest when dealing with concave corners.
 
 .. literalinclude:: ../tutorial/aero/meshing/volume/run_pyhyp.py

--- a/machAeroTutorials/opt_aero.rst
+++ b/machAeroTutorials/opt_aero.rst
@@ -105,7 +105,7 @@ We can set up constraints on the geometry with the DVConstraints class, also fou
 There are several built-in constraint functions within the DVConstraints class, including thickness, surface area, volume, location, and general linear constraints.
 The majority of the constraints are defined based on a triangulated-surface representation of the wing obtained from ADflow.
 
-.. note:: The triangulated surface is created by ADflow (or DAfoam) using the wall surfaces defined in the CFD volume mesh. The resolution is similar to the CFD surface mesh, and users do not need to provide this triangulated mesh themselves. Optionally, this can also be defined with an external file, see the details `here <https://github.com/mdolab/pygeo/blob/master/pygeo/DVConstraints.py#L200>`_. This is useful if users want to have a different resolution on the triangulated surface (finer or coarser) compared to the CFD mesh, or if DVConstraints is being used without ADflow (or DAfoam).
+.. note:: The triangulated surface is created by ADflow (or DAfoam) using the wall surfaces defined in the CFD volume mesh. The resolution is similar to the CFD surface mesh, and users do not need to provide this triangulated mesh themselves. Optionally, this can also be defined with an external file, see the docstrings for :meth:`setSurface() <pygeo:pygeo.DVConstraints.setSurface>`. This is useful if users want to have a different resolution on the triangulated surface (finer or coarser) compared to the CFD mesh, or if DVConstraints is being used without ADflow (or DAfoam).
 
 The volume and thickness constraints are set up by creating a uniformly spaced 2D grid of points, which is then projected onto the upper and lower surface of a triangulated-surface representation of the wing.
 The grid is defined by providing four corner points (using ``leList`` and ``teList``) and by specifying the number of spanwise and chordwise points (using ``nSpan`` and ``nChord``).
@@ -124,7 +124,7 @@ Therefore, ``lower=1.0`` in this example means that the lower limits for these c
 For the volume constraint, the volume is computed by adding up the volumes of the prisms that make up the projected grid as illustrated in the following image (only showing a section for clarity).
 For the thickness constraints, the distances between the upper and lower projected points are used, as illustrated in the following image.
 During optimization, these projected points are also moved by the FFD, just like the wing surface, and are used again to calculate the thicknesses and volume for the new designs.
-More information on the options can be found in the `pyGeo docs <https://mdolab-pygeo.readthedocs-hosted.com/>`_ or by looking at the pyGeo source code.
+More information on the options can be found in the :doc:`pyGeo docs <pygeo:index>` or by looking at the pyGeo source code.
 
 .. image:: images/opt_thickness_and_vol_diagram.png
    :scale: 40

--- a/machAeroTutorials/opt_pyopt.rst
+++ b/machAeroTutorials/opt_pyopt.rst
@@ -9,7 +9,7 @@ Introduction
 Although we specialize in optimization, we don't write our own optimization algorithms.
 We like to work a little closer to the applications side, and we figure that the mathematicians have already done an exceptional job developing the algorithms.
 In fact, there are many great optimization algorithms out there, each with different advantages.
-From the user's perspective most of these algorithms have similar inputs and outputs, so we decided to develop a library for optimization algorithms with a common interface: `pyOptSparse <https://github.com/mdolab/pyoptsparse>`_.
+From the user's perspective most of these algorithms have similar inputs and outputs, so we decided to develop a library for optimization algorithms with a common interface: :doc:`pyOptSparse <pyoptsparse:index>`.
 pyOptSparse allows the user to switch between several algorithms by changing a single argument.
 This facilitates comparison between different techniques and allows the user to focus on the other aspects of building an optimization problem.
 

--- a/machFramework/MACH-Aero.rst
+++ b/machFramework/MACH-Aero.rst
@@ -7,17 +7,17 @@ This page provides an overview of the aerodynamic shape optimization capability 
 
 MACH-Aero consists of six major modules:
 
-- Pre-processing (`pyHyp <https://mdolab-pyhyp.readthedocs-hosted.com>`_, `ANSYS ICEM-CFD <https://ansys.com>`_)
+- Pre-processing (:doc:`pyHyp <pyhyp:index>`, `ANSYS ICEM-CFD <https://ansys.com>`_)
 
-- Geometry parameterization (`pyGeo <https://mdolab-pygeo.readthedocs-hosted.com>`_)
+- Geometry parameterization (:doc:`pyGeo <pygeo:index>`)
 
-- Volume mesh deformation (`IDWarp <https://mdolab-idwarp.readthedocs-hosted.com>`_)
+- Volume mesh deformation (:doc:`IDWarp <idwarp:index>`)
 
-- Flow simulation (`ADflow <https://mdolab-adflow.readthedocs-hosted.com>`_, `DAFoam <https://dafoam.github.io/>`_)
+- Flow simulation (:doc:`ADflow <adflow:index>`, `DAFoam <https://dafoam.github.io/>`_)
 
-- Adjoint computation (`ADflow <https://mdolab-adflow.readthedocs-hosted.com>`_, `DAFoam <https://dafoam.github.io/>`_)
+- Adjoint computation (:doc:`ADflow <adflow:index>`, `DAFoam <https://dafoam.github.io/>`_)
 
-- Optimization (`pyOptSparse <https://mdolab-pyoptsparse.readthedocs-hosted.com>`_)
+- Optimization (:doc:`pyOptSparse <pyoptsparse:index>`)
 
 .. image:: images/AeroOpt.png
 
@@ -29,15 +29,15 @@ The diagonal nodes represent the modules and the off-diagonal nodes represent th
 The black lines represent the process flow for the adjoint solver, whereas the thick gray lines represent the data flow.
 The number in each node represents the execution order:
 
-- First, we generate a volume mesh for the baseline geometry (pre-processing in process 1). Several mesh generation tools are available including `pyHyp <https://mdolab-pyhyp.readthedocs-hosted.com>`_ and ICEM. Refer to :ref:`Surface Meshing <aero_icem>`, :ref:`Volume Meshing <aero_pyhyp>`, and :ref:`Mesh Manipulation <aero_cgnsutils>` for more details. The generated mesh will be used later in process 4. In the pre-processing step, we also generate free-form deformation (FFD) points (process 3) that will be used later to morph the design surface. Refer to :ref:`Geometric Parameterization <opt_ffd>`.
+- First, we generate a volume mesh for the baseline geometry (pre-processing in process 1). Several mesh generation tools are available including :doc:`pyHyp <pyhyp:index>` and ICEM. Refer to :ref:`Surface Meshing <aero_icem>`, :ref:`Volume Meshing <aero_pyhyp>`, and :ref:`Mesh Manipulation <aero_cgnsutils>` for more details. The generated mesh will be used later in process 4. In the pre-processing step, we also generate free-form deformation (FFD) points (process 3) that will be used later to morph the design surface. Refer to :ref:`Geometric Parameterization <opt_ffd>`.
 
-- Then, we give a set of baseline design variables to the optimizer (process 2). We usually use SNOPT as the optimizer, which uses the SQP algorithm. We use `pyOptSparse <https://mdolab-pyoptsparse.readthedocs-hosted.com>`_ to facilitate the optimization problem setup. The optimizer will update the design variables and give them to the geometry parameterization module (`pyGeo <https://mdolab-pygeo.readthedocs-hosted.com>`_; process 3). pyGeo receives the updated design variables and the FFD points generated in the pre-processing step, performs the deformation for the design surface, and outputs the deformed design surface to the mesh deformation module (`IDWarp <https://mdolab-idwarp.readthedocs-hosted.com>`_) in process 4. pyGeo also computes the values of geometric constraints and their derivatives with respect to the design variables (process 7).
+- Then, we give a set of baseline design variables to the optimizer (process 2). We usually use SNOPT as the optimizer, which uses the SQP algorithm. We use :doc:`pyOptSparse <pyoptsparse:index>` to facilitate the optimization problem setup. The optimizer will update the design variables and give them to the geometry parameterization module (:doc:`pyGeo <pygeo:index>`; process 3). pyGeo receives the updated design variables and the FFD points generated in the pre-processing step, performs the deformation for the design surface, and outputs the deformed design surface to the mesh deformation module (:doc:`IDWarp <idwarp:index>`) in process 4. pyGeo also computes the values of geometric constraints and their derivatives with respect to the design variables (process 7).
 
-- Next, `IDWarp <https://mdolab-idwarp.readthedocs-hosted.com>`_ deforms the volume mesh based on the updated design surface and outputs the updated volume mesh to the flow simulation module in process 5.
+- Next, :doc:`IDWarp <idwarp:index>` deforms the volume mesh based on the updated design surface and outputs the updated volume mesh to the flow simulation module in process 5.
 
-- The flow simulation module receives the updated volume mesh and uses high-fidelity CFD tools (i.e., `ADflow <https://mdolab-adflow.readthedocs-hosted.com>`_ or `DAFoam <https://dafoam.github.io/>`_) to compute the state variables (process 6) or physical fields (pressure, density, velocity, etc.). The flow simulation module also computes the objective and constraint functions (e.g., drag and lift; see process 7) and outputs the state variables to the adjoint computation module.
+- The flow simulation module receives the updated volume mesh and uses high-fidelity CFD tools (i.e., :doc:`ADflow <adflow:index>` or `DAFoam <https://dafoam.github.io/>`_) to compute the state variables (process 6) or physical fields (pressure, density, velocity, etc.). The flow simulation module also computes the objective and constraint functions (e.g., drag and lift; see process 7) and outputs the state variables to the adjoint computation module.
 
-- Then, the adjoint computation module (process 6) computes the total derivatives of the objective and constraint functions with respect to the design variables (process 7) and gives them back to the optimizer in process 7. The benefit of using the adjoint method to compute derivatives is that its computational cost is independent of the number of design variables, which makes it attractive for handling large-scale, complex design problems such as aircraft design. There are two available adjoint solvers: `ADflow <https://mdolab-adflow.readthedocs-hosted.com>`_, `DAFoam <https://dafoam.github.io/>`_.
+- Then, the adjoint computation module (process 6) computes the total derivatives of the objective and constraint functions with respect to the design variables (process 7) and gives them back to the optimizer in process 7. The benefit of using the adjoint method to compute derivatives is that its computational cost is independent of the number of design variables, which makes it attractive for handling large-scale, complex design problems such as aircraft design. There are two available adjoint solvers: :doc:`ADflow <adflow:index>`, `DAFoam <https://dafoam.github.io/>`_.
 
 - Finally, the optimizer receives the values and derivatives of the objective and constraint functions in process 7, performs the SQP computation, and outputs a set of updated design variables to pyGeo.
 


### PR DESCRIPTION
## Purpose
I removed the SWIG section and added it to the list of packages to be `apt`-installed. Through testing we have found that we no longer require precisely v2.0.12, so system-provided SWIG is fine for most cases.

I also updated links to use intersphinx pretty much everywhere.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update
