### PR TITLE
Temp fix - skipping IPOPT on intel images

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,7 +2,6 @@ import os
 import unittest
 import subprocess
 import shutil
-from pyoptsparse.pyOpt_error import Error
 
 tutorialDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../tutorial")  # Path to current folder
 has_SNOPT = os.environ.get("IMAGE") == "private"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -10,6 +10,11 @@ try:
 except ImportError:
     pyOCSM = None
 
+try:
+    from pyoptsparse.pyIPOPT import pyipoptcore
+except ImportError:
+    pyipoptcore = None
+
 # note that this is NOT the testflo directive!
 # we are explicitly calling mpirun ourselves
 NPROCS = 2
@@ -78,6 +83,7 @@ class TestWingOpt(unittest.TestCase):
         cmd = ["python", "aero_opt.py"]
         subprocess.check_call(mpiCmd + cmd + gridFlag + SNOPT)
 
+    @unittest.skipIf(pyipoptcore is None, "temporarily skipping IPOPT tests on the intel image")
     def test_wing_opt_IPOPT(self):
         # first copy files
         os.chdir("aero")

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,7 +5,7 @@ import shutil
 
 tutorialDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../tutorial")  # Path to current folder
 has_SNOPT = os.environ.get("IMAGE") == "private"
-has_IPOPT = os.environ.get("OS") == "centos" and os.environ.get("COMPILERS") == "intel"
+has_not_IPOPT = os.environ.get("OS") == "centos" and os.environ.get("COMPILERS") == "intel"
 try:
     from pyOCSM import pyOCSM
 except ImportError:
@@ -80,7 +80,7 @@ class TestWingOpt(unittest.TestCase):
         cmd = ["python", "aero_opt.py"]
         subprocess.check_call(mpiCmd + cmd + gridFlag + SNOPT)
 
-    @unittest.skipUnless(has_IPOPT, "temporarily skipping IPOPT tests on the intel image")
+    @unittest.skipIf(has_not_IPOPT, "temporarily skipping IPOPT tests on the intel image")
     def test_wing_opt_IPOPT(self):
         # first copy files
         os.chdir("aero")

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -6,6 +6,7 @@ from pyoptsparse.pyOpt_error import Error
 
 tutorialDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../tutorial")  # Path to current folder
 has_SNOPT = os.environ.get("IMAGE") == "private"
+has_IPOPT = os.environ.get("OS") == "centos" and os.environ.get("COMPILERS") == "intel"
 try:
     from pyOCSM import pyOCSM
 except ImportError:
@@ -80,6 +81,7 @@ class TestWingOpt(unittest.TestCase):
         cmd = ["python", "aero_opt.py"]
         subprocess.check_call(mpiCmd + cmd + gridFlag + SNOPT)
 
+    @unittest.skipUnless(has_IPOPT, "temporarily skipping IPOPT tests on the intel image")
     def test_wing_opt_IPOPT(self):
         # first copy files
         os.chdir("aero")
@@ -87,10 +89,7 @@ class TestWingOpt(unittest.TestCase):
         shutil.copy("../../aero/analysis/wing_vol_coarsen.cgns", "wing_vol_coarsen.cgns")
         shutil.rmtree("output_IPOPT", ignore_errors=True)
         cmd = ["python", "aero_opt.py", "--output", "output_IPOPT"]
-        try:
-            subprocess.check_call(mpiCmd + cmd + gridFlag + IPOPT)
-        except Error:
-            unittest.SkipTest("temporarily skipping IPOPT tests on the intel image")
+        subprocess.check_call(mpiCmd + cmd + gridFlag + IPOPT)
 
     @unittest.skipUnless(has_SNOPT and pyOCSM is not None, "SNOPT and pyOCSM are required for this test")
     def test_wing_opt_ESP_SNOPT(self):


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
Until we implement a way to install and test IPOPT on intel container (capability removed as we [switched to pyenv on the docker images](https://github.com/mdolab/docker/pull/154)), we add a `skiptest` decorator to the related MACH-Aero test.
Given the logic described [here](https://github.com/mdolab/MACH-Aero/blob/57f4b4526dda81ce36718894109a85f0f6498fce/.github/test_real.sh#L5), this is only enabled on intel-compiled images.

This PR needs to be reverted as soon as IPOPT becomes available again.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
