### PR TITLE
Add general contribution guide

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -29,6 +29,7 @@ If you use any of our codes, please :ref:`cite us <cite-us>`.
 
    machFramework/MACH-Aero.rst
    machFramework/citeUs.rst
+   machFramework/contribute.rst
 
 .. toctree::
    :caption: Installation

--- a/machFramework/contribute.rst
+++ b/machFramework/contribute.rst
@@ -18,7 +18,13 @@ Python
 ^^^^^^
 
 We use `black <https://github.com/psf/black>`_ for formatting Python codes.
-Please install it following its documentation and run it at the project root with:
+The version we use can be installed with:
+
+.. prompt:: bash
+
+    pip install black==22.3.0
+
+``black`` can then be run at the project root with:
 
 .. prompt:: bash
 
@@ -27,38 +33,54 @@ Please install it following its documentation and run it at the project root wit
 This will automatically format all Python files.
 
 We use `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting in Python.
-Please install it following its instructions and run it at the project root with:
+The recommended version and any necessary dependencies are in `this file <https://github.com/mdolab/.github/blob/main/flake8-requirements.txt>`_.
+You can install them by calling ``pip install`` for each individually or copying the contents of that file into one on your machine and typing:
+
+.. prompt:: bash
+
+    pip install flake8-requirements.txt
+
+The configuration file we use for ``flake8`` is a combination of `this .flake8 file <https://github.com/mdolab/.github/blob/main/.flake8>`__ and the one at the root of the respective repository.
+``flake8`` can then be run at the project root with:
 
 .. prompt:: bash
 
     flake8 .
 
-The configuration file we use for ``flake8`` is a combination of `this .flake8 file <https://github.com/mdolab/.github/blob/main/.flake8>`__ and the one at the root of the respective repository.
 If there are any PEP-8 violations, ``flake8`` will print out the nature of the violation.
 
 Fortran
 ^^^^^^^
 
 We use `fprettify <https://github.com/pseewald/fprettify>`_ for formatting Fortran codes. 
-Please install it following its documentation and run it at the project root with:
+The version we use can be installed with:
+
+.. prompt:: bash 
+
+    pip install fprettify==0.3.7
+
+The configuration file for ``fprettify`` is at the root of the respective repository.
+If there isn't a repo-specific config, `this global fprettify config <https://github.com/mdolab/.github/blob/main/.fprettify.rc>`_ is used.
+``fprettify`` can then be run at the project root using `this fprettify bash script <https://github.com/mdolab/.github/blob/main/azure/fprettify.sh>`_ with:
 
 .. prompt:: bash
 
-    fprettify -i=4 -l=120 --whitespace-multdiv=True --strict-indent
-
-The configuration file for ``fprettify`` is a combination of `this .fprettify.rc file <https://github.com/mdolab/.github/blob/main/.fprettify.rc>`_ and the one at the root of the respective repository.
+    ./fprettify.sh
 
 C/C++
 ^^^^^
 
-We use `ClangFormat <https://clang.llvm.org/>`_ to format C/C++ codes. 
-Please install it following its documentation and run at the project root with:
+We use `clang-format <https://clang.llvm.org/>`_ to format C/C++ codes. 
+Please install **version 10** following its documentation.
+
+The configuration file for ``clang-format`` is at the root of the respective repository.
+If there isn't a repo-specific config, `this global clang-format config <https://github.com/mdolab/.github/blob/main/.clang-format>`_ is used.
+``clang-format`` can then be run at the project root using `this clang-format bash script <https://github.com/mdolab/.github/blob/main/azure/clang-format.sh>`_ with:
 
 .. prompt:: bash
 
-    clang-format
+    ./clang-format.sh
 
-The configuration file for ``ClangFormat`` is a combination of `this .clang-format file <https://github.com/mdolab/.github/blob/main/.clang-format>`_ and the one at the root of the respective repo
 
 .. warning::
     For a PR to be accepted it must pass formatting checks with the relevant formatter and/or linter.
@@ -66,7 +88,7 @@ The configuration file for ``ClangFormat`` is a combination of `this .clang-form
 Documentation
 -------------
 When you add or modify code, make sure to provide relevant documentation that explains the new code.
-This should be done in code via docstrings and comments as well as in the Sphinx documentation if you add a new feature or capability.
+This should be done in code via docstrings and comments as well in the Sphinx documentation if you add a new feature or capability.
 Look at the ``.rst`` files in the ``doc`` section of each repo.
 
 Building the documentation requires ``sphinx`` and ``numpydoc``, as well as the Sphinx RTD theme.
@@ -74,7 +96,7 @@ To install these dependencies, type
 
 .. prompt:: bash
 
-    pip install sphinx numpydoc sphinx-rtd-theme
+    pip install sphinx numpydoc sphinx-rtd-theme sphinx-mdolab-theme
 
 To build documentation locally, go to the ``doc`` folder and type 
 
@@ -88,7 +110,7 @@ Testing
 -------
 When you add code or functionality, add tests that cover the new or modified code.
 These may be units tests for individual components or regression tests for entire models that use the new functionality.
-All the existing tests can be found under the ``test`` folder.
+All the existing tests can be found under the ``tests`` folder.
 Running tests requires additional packages in some repos, to install these you can go to the root of that repo and type:
 
 .. prompt:: bash 
@@ -99,7 +121,7 @@ We use `Codecov <https://about.codecov.io/>`_ to monitor the percentage of the c
 Coverage can be difficult to determine locally, so it is recommended to look for the check automatically run in the pull request. 
 
 .. warning::
-    For a PR to be accepted all existing tests must pass and new code should meet coverage requirements.
+    For a PR to be accepted, all existing tests must pass and new code should meet coverage requirements.
 
 Pull requests
 -------------

--- a/machFramework/contribute.rst
+++ b/machFramework/contribute.rst
@@ -1,6 +1,8 @@
 How to Contribute to MACH-Aero
 ==============================
 The codes in the MACH-Aero framework are open-source tools, so we welcome users to submit additions or fixes to improve them for everyone.
+This page contains general information on how to contribute to MACH-Aero codes.
+If a repo has additional instructions they will be in that repo's documentation, which can be found from its GitHub page. 
 
 Issues
 ------

--- a/machFramework/contribute.rst
+++ b/machFramework/contribute.rst
@@ -40,7 +40,7 @@ You can install them by calling ``pip install`` for each individually or copying
 
 .. prompt:: bash
 
-    pip install flake8-requirements.txt
+    pip install -r flake8-requirements.txt
 
 The configuration file we use for ``flake8`` is a combination of `this .flake8 file <https://github.com/mdolab/.github/blob/main/.flake8>`__ and the one at the root of the respective repository.
 ``flake8`` can then be run at the project root with:
@@ -93,12 +93,12 @@ When you add or modify code, make sure to provide relevant documentation that ex
 This should be done in code via docstrings and comments as well as in the Sphinx documentation if you add a new feature or capability.
 Look at the ``.rst`` files in the ``doc`` section of each repo.
 
-Building the documentation requires ``sphinx`` and ``numpydoc``, as well as the Sphinx RTD theme.
-To install these dependencies, type:
+Building the documentation requires our custom Sphinx theme.
+To install the MDO Lab theme and its dependencies, type:
 
 .. prompt:: bash
 
-    pip install sphinx numpydoc sphinx-rtd-theme sphinx-mdolab-theme
+    pip install sphinx-mdolab-theme
 
 To build documentation locally, go to the ``doc`` folder and type: 
 
@@ -113,7 +113,8 @@ Testing
 When you add code or functionality, add tests that cover the new or modified code.
 These may be units tests for individual components or regression tests for entire models that use the new functionality.
 All the existing tests can be found under the ``tests`` folder.
-Running tests requires additional packages in some repos, to install these you can go to the root of that repo and type:
+Running tests requires additional packages in some repos.
+To install these, go to the root of that repo and type:
 
 .. prompt:: bash 
 

--- a/machFramework/contribute.rst
+++ b/machFramework/contribute.rst
@@ -1,0 +1,108 @@
+How to Contribute to MACH-Aero
+==============================
+The codes in the MACH-Aero framework are open-source tools, so we welcome users to submit additions or fixes to improve them for everyone.
+
+Issues
+------
+If you have an issue, a bug to report, or a feature to request, submit an issue on the GitHub repository for that specific code.
+This lets other users know about the issue.
+If you are comfortable fixing the issue, please do so and submit a pull request from a branch on your own fork of that repo.
+
+Coding style
+------------
+We use formatters specific to different programming languages to increase readability and standardization of code. 
+We run continuous integration with these tools on all pull requests submitted.
+For an easier workflow, we recommend integrating these tools with your code editor.
+
+Python
+^^^^^^
+
+We use `black <https://github.com/psf/black>`_ for formatting Python codes.
+Please install it following its documentation and run it at the project root with:
+
+.. prompt:: bash
+
+    black . -l 120
+
+This will automatically format all Python files.
+
+We use `flake8 <https://flake8.pycqa.org/en/latest/>`_ for linting in Python.
+Please install it following its instructions and run it at the project root with:
+
+.. prompt:: bash
+
+    flake8 .
+
+The configuration file we use for ``flake8`` is a combination of `this .flake8 file <https://github.com/mdolab/.github/blob/main/.flake8>`__ and the one at the root of the respective repository.
+If there are any PEP-8 violations, ``flake8`` will print out the nature of the violation.
+
+Fortran
+^^^^^^^
+
+We use `fprettify <https://github.com/pseewald/fprettify>`_ for formatting Fortran codes. 
+Please install it following its documentation and run it at the project root with:
+
+.. prompt:: bash
+
+    fprettify -i=4 -l=120 --whitespace-multdiv=True --strict-indent
+
+The configuration file for ``fprettify`` is a combination of `this .fprettify.rc file <https://github.com/mdolab/.github/blob/main/.fprettify.rc>`_ and the one at the root of the respective repository.
+
+C/C++
+^^^^^
+
+We use `ClangFormat <https://clang.llvm.org/>`_ to format C/C++ codes. 
+Please install it following its documentation and run at the project root with:
+
+.. prompt:: bash
+
+    clang-format
+
+The configuration file for ``ClangFormat`` is a combination of `this .clang-format file <https://github.com/mdolab/.github/blob/main/.clang-format>`_ and the one at the root of the respective repo
+
+.. warning::
+    For a PR to be accepted it must pass formatting checks with the relevant formatter and/or linter.
+
+Documentation
+-------------
+When you add or modify code, make sure to provide relevant documentation that explains the new code.
+This should be done in code via docstrings and comments as well as in the Sphinx documentation if you add a new feature or capability.
+Look at the ``.rst`` files in the ``doc`` section of each repo.
+
+Building the documentation requires ``sphinx`` and ``numpydoc``, as well as the Sphinx RTD theme.
+To install these dependencies, type
+
+.. prompt:: bash
+
+    pip install sphinx numpydoc sphinx-rtd-theme
+
+To build documentation locally, go to the ``doc`` folder and type 
+
+.. prompt:: bash
+
+    make html
+
+The HTML files are then generated in ``_build/html`` and can be viewed in a web browser.
+
+Testing
+-------
+When you add code or functionality, add tests that cover the new or modified code.
+These may be units tests for individual components or regression tests for entire models that use the new functionality.
+All the existing tests can be found under the ``test`` folder.
+Running tests requires additional packages in some repos, to install these you can go to the root of that repo and type:
+
+.. prompt:: bash 
+
+    pip install .[testing]
+
+We use `Codecov <https://about.codecov.io/>`_ to monitor the percentage of the code covered by tests. 
+Coverage can be difficult to determine locally, so it is recommended to look for the check automatically run in the pull request. 
+
+.. warning::
+    For a PR to be accepted all existing tests must pass and new code should meet coverage requirements.
+
+Pull requests
+-------------
+Finally, after adding or modifying code and making sure the steps above are followed, submit a pull request via the GitHub interface.
+This will automatically go through every test in the repo to make sure everything is functioning properly as well as check the formatting and the code coverage.
+The main developers of the respective repo will then merge in the request or provide feedback on how to improve the contribution.


### PR DESCRIPTION
## Purpose
We have a contribution guide for pyOptSparse but most of the info is generally applicable to the lab's codes so it can be centralized. After this is made, other repos can link to it from their docs and include additional info specific to the individual repos on their own contribution page. 

## Expected time until merged
Soon, not a major change

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
N/A

## Checklist
- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
