### PR TITLE
Fixed Intel image test skipping

### DIFF
--- a/.github/test_real.sh
+++ b/.github/test_real.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# all tests should pass on private
-if [[ $IMAGE == "private" ]] && [[ $OS == "ubuntu" ]]; then
+# All tests should pass on private images with non-Intel MPI
+if [[ $IMAGE == "private" ]] && [[ -z $I_MPI_ROOT ]]; then
     EXTRA_FLAGS='--disallow_skipped'
 fi
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,7 +5,7 @@ import shutil
 
 tutorialDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../tutorial")  # Path to current folder
 has_SNOPT = os.environ.get("IMAGE") == "private"
-has_not_IPOPT = os.environ.get("OS") == "centos" and os.environ.get("COMPILERS") == "intel"
+has_not_IPOPT = os.environ.get("COMPILERS") == "intel"
 try:
     from pyOCSM import ocsm
 except ImportError:


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
The newly added Intel image failed on the last nightly test because some of the test skipping logic was broken. I fixed this by:
1) Only checking for Intel compilers to set the IPOPT flag instead of also checking for CentOS
2) Checking for non-Intel MPI images instead of Ubuntu when passing the `--disallow_skipped` flag to testflo

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
ASAP

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
