### PR TITLE
Edited plotting file to cater for all the optimizers. Added a main fu…

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -91,6 +91,9 @@ class TestWingOpt(unittest.TestCase):
     @parameterized.expand(["SLSQP", "SNOPT", "IPOPT"])
     @unittest.skipIf(ocsm is None, "pyOCSM is required for this test")
     def test_wing_opt_ESP(self, optName):
+        # Check if anything needs to be skipped based on available optimizers and modules
+        if optName == "SNOPT" and not has_SNOPT:
+            raise unittest.SkipTest("SNOPT is required for this test")
         self._prepareDirAndFiles()
         shutil.rmtree("output_ESP", ignore_errors=True)
         cmd = ["python", "aero_opt_esp.py", "--output", "output_ESP"]

--- a/tutorial/opt/aero/plot_optHist.py
+++ b/tutorial/opt/aero/plot_optHist.py
@@ -11,7 +11,7 @@ def main(args):
     opt_hist = History(args.histFile)
     hist_values = opt_hist.getValues()
 
-    if opt_hist.getMetadata()['optimizer'] == "SNOPT":
+    if opt_hist.getMetadata()["optimizer"] == "SNOPT":
         _, axes = plt.subplots(nrows=5, sharex=True, figsize=(10, 14))
 
         # Objective Optimality and Feasibility
@@ -41,7 +41,7 @@ def main(args):
     # Lift Constraint
     axes[3].plot("iter", "cl_con_wing", data=hist_values, label="Lift Constraint")
     axes[3].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
-    
+
     # Adjust subplot aesthetics
     for ax in axes:
         ax.spines["right"].set_visible(False)

--- a/tutorial/opt/aero/plot_optHist.py
+++ b/tutorial/opt/aero/plot_optHist.py
@@ -4,9 +4,57 @@ import matplotlib.pyplot as plt
 from pyoptsparse import History
 
 
-def main():
+def main(args):
+    if not os.path.isfile(args.histFile):
+        raise FileNotFoundError(f"History file '{args.histFile}' not found.")
 
-    plt.rcParams["text.usetex"] = True  # Comment out if latex installation is not present
+    opt_hist = History(args.histFile)
+    hist_values = opt_hist.getValues()
+
+    if opt_hist.getMetadata()['optimizer'] == "SNOPT":
+        _, axes = plt.subplots(nrows=5, sharex=True, figsize=(10, 14))
+
+        # Objective Optimality and Feasibility
+        axes[4].plot("nMajor", "optimality", data=hist_values, label="Optimality")
+        axes[4].plot("nMajor", "feasibility", data=hist_values, label="Feasibility")
+        axes[4].set_yscale("log")
+        axes[4].axhline(1e-4, linestyle="--", color="gray")
+        axes[4].annotate("Convergence Criteria", xy=(3, 9e-5), ha="left", va="top", fontsize=24, color="gray")
+        axes[4].legend(fontsize=20, labelcolor="linecolor", loc="upper right", frameon=False)
+        axes[4].autoscale(enable=True, tight=True)
+
+    else:
+        _, axes = plt.subplots(nrows=4, sharex=True, figsize=(10, 14))
+
+    # Objective (Drag Coefficient)
+    axes[0].plot("iter", "obj", data=hist_values, label="Objective ($C_D$)")
+    axes[0].set_ylabel("Objective ($C_D$)", rotation="horizontal", ha="right", fontsize=24)
+
+    # Angle of Attack
+    axes[1].plot("iter", "alpha_wing", data=hist_values, label="Angle of Attack")
+    axes[1].set_ylabel(r"$\alpha$ [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
+
+    # Wing Twist
+    axes[2].plot("iter", "twist", data=hist_values, label="Wing Twist")
+    axes[2].set_ylabel("Twist [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
+
+    # Lift Constraint
+    axes[3].plot("iter", "cl_con_wing", data=hist_values, label="Lift Constraint")
+    axes[3].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
+    
+    # Adjust subplot aesthetics
+    for ax in axes:
+        ax.spines["right"].set_visible(False)
+        ax.spines["top"].set_visible(False)
+        ax.spines["left"].set_position(("outward", 12))
+        ax.spines["bottom"].set_position(("outward", 12))
+
+    plt.show()
+    plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.jpg"), bbox_inches="tight")
+
+
+if __name__ == "__main__":
+    # plt.rcParams["text.usetex"] = True  # Comment out if latex installation is not present
     plt.rcParams["font.family"] = "serif"
     plt.rcParams["font.size"] = 20
     plt.rcParams["xtick.labelsize"] = 16
@@ -15,80 +63,7 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--histFile", type=str, default="opt.hst")
-    parser.add_argument("--opt", type=str, default="SLSQP", choices=["IPOPT", "SLSQP", "SNOPT"])
     parser.add_argument("--outputDir", type=str, default="./")
     args = parser.parse_args()
 
-    try:
-        if not os.path.isfile(args.histFile):
-            raise FileNotFoundError(f"History file '{args.histFile}' not found.")
-
-        optHist = History(args.histFile)
-        histValues = optHist.getValues()
-
-        if args.opt == "SNOPT":
-
-            _, axes = plt.subplots(nrows=5, sharex=True, figsize=(10, 14))
-
-            # Objective Optimality and Feasibility
-            axes[0].plot("nMajor", "optimality", data=histValues, label="Optimality")
-            axes[0].plot("nMajor", "feasibility", data=histValues, label="Feasibility")
-            axes[0].set_yscale("log")
-            axes[0].axhline(1e-4, linestyle="--", color="gray")
-            axes[0].annotate("Convergence Criteria", xy=(3, 9e-5), ha="left", va="top", fontsize=24, color="gray")
-            axes[0].legend(fontsize=20, labelcolor="linecolor", loc="upper right", frameon=False)
-            axes[0].autoscale(enable=True, tight=True)
-
-            # Objective (Drag Coefficient)
-            axes[1].plot("iter", "obj", data=histValues, label="Objective ($C_D$)")
-            axes[1].set_ylabel("Objective ($C_D$)", rotation="horizontal", ha="right", fontsize=24)
-
-            # Angle of Attack
-            axes[2].plot("iter", "alpha_wing", data=histValues, label="Angle of Attack")
-            axes[2].set_ylabel(r"$\alpha$ [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
-
-            # Wing Twist
-            axes[3].plot("iter", "twist", data=histValues, label="Wing Twist")
-            axes[3].set_ylabel("Twist [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
-
-            # Lift Constraint
-            axes[4].plot("iter", "cl_con_wing", data=histValues, label="Lift Constraint")
-            axes[4].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
-
-        else:
-
-            _, axes = plt.subplots(nrows=4, sharex=True, figsize=(10, 14))
-
-            # Objective (Drag Coefficient)
-
-            axes[0].plot("iter", "obj", data=histValues, label="Objective ($C_D$)")
-            axes[0].set_ylabel("Objective ($C_D$)", rotation="horizontal", ha="right", fontsize=24)
-
-            # Angle of Attack
-            axes[1].plot("iter", "alpha_wing", data=histValues, label="Angle of Attack")
-            axes[1].set_ylabel(r"$\alpha$ [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
-
-            # Wing Twist
-            axes[2].plot("iter", "twist", data=histValues, label="Wing Twist")
-            axes[2].set_ylabel("Twist [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
-
-            # Lift Constraint
-            axes[3].plot("iter", "cl_con_wing", data=histValues, label="Lift Constraint")
-            axes[3].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
-
-        # Adjust subplot aesthetics
-        for ax in axes:
-            ax.spines["right"].set_visible(False)
-            ax.spines["top"].set_visible(False)
-            ax.spines["left"].set_position(("outward", 12))
-            ax.spines["bottom"].set_position(("outward", 12))
-
-        plt.show()
-        plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.jpg"), bbox_inches="tight")
-
-    except FileNotFoundError as fnf_error:
-        print(fnf_error)
-
-
-if __name__ == "__main__":
-    main()
+    main(args)

--- a/tutorial/opt/aero/plot_optHist.py
+++ b/tutorial/opt/aero/plot_optHist.py
@@ -3,6 +3,7 @@ import argparse
 import matplotlib.pyplot as plt
 from pyoptsparse import History
 
+
 def main():
 
     plt.rcParams["text.usetex"] = True  # Comment out if latex installation is not present
@@ -21,7 +22,7 @@ def main():
     try:
         if not os.path.isfile(args.histFile):
             raise FileNotFoundError(f"History file '{args.histFile}' not found.")
-        
+
         optHist = History(args.histFile)
         histValues = optHist.getValues()
 
@@ -83,10 +84,11 @@ def main():
             ax.spines["bottom"].set_position(("outward", 12))
 
         plt.show()
-        plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.jpg"), bbox_inches = 'tight')
-    
+        plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.jpg"), bbox_inches="tight")
+
     except FileNotFoundError as fnf_error:
         print(fnf_error)
+
 
 if __name__ == "__main__":
     main()

--- a/tutorial/opt/aero/plot_optHist.py
+++ b/tutorial/opt/aero/plot_optHist.py
@@ -3,49 +3,90 @@ import argparse
 import matplotlib.pyplot as plt
 from pyoptsparse import History
 
-plt.rcParams["text.usetex"] = True  # Comment out if latex installation is not present
-plt.rcParams["font.family"] = "serif"
-plt.rcParams["font.size"] = 20
-plt.rcParams["xtick.labelsize"] = 16
-plt.rcParams["ytick.labelsize"] = 16
-plt.rcParams["lines.linewidth"] = 3.0
+def main():
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--histFile", type=str, default="opt.hst")
-parser.add_argument("--outputDir", type=str, default="./")
-args = parser.parse_args()
+    plt.rcParams["text.usetex"] = True  # Comment out if latex installation is not present
+    plt.rcParams["font.family"] = "serif"
+    plt.rcParams["font.size"] = 20
+    plt.rcParams["xtick.labelsize"] = 16
+    plt.rcParams["ytick.labelsize"] = 16
+    plt.rcParams["lines.linewidth"] = 3.0
 
-optHist = History(args.histFile)
-histValues = optHist.getValues()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--histFile", type=str, default="opt.hst")
+    parser.add_argument("--opt", type=str, default="SLSQP", choices=["IPOPT", "SLSQP", "SNOPT"])
+    parser.add_argument("--outputDir", type=str, default="./")
+    args = parser.parse_args()
 
-fig, axes = plt.subplots(nrows=5, sharex=True, constrained_layout=True, figsize=(14, 10))
+    try:
+        if not os.path.isfile(args.histFile):
+            raise FileNotFoundError(f"History file '{args.histFile}' not found.")
+        
+        optHist = History(args.histFile)
+        histValues = optHist.getValues()
 
-axes[0].plot("nMajor", "optimality", data=histValues, label="Optimality")
-axes[0].plot("nMajor", "feasibility", data=histValues, label="Feasibility")
-axes[0].set_yscale("log")
-axes[0].axhline(1e-4, linestyle="--", color="gray")
-axes[0].annotate("Convergence Criteria", xy=(3, 9e-5), ha="left", va="top", fontsize=24, color="gray")
-axes[0].legend(fontsize=20, labelcolor="linecolor", loc="upper right", frameon=False)
-axes[0].autoscale(enable=True, tight=True)
+        if args.opt == "SNOPT":
 
-axes[1].plot("nMajor", "obj", data=histValues, label="Objective")
-axes[1].set_ylabel("Objective \n($C_D$)", rotation="horizontal", ha="right", fontsize=24)
+            _, axes = plt.subplots(nrows=5, sharex=True, figsize=(10, 14))
 
-axes[2].plot("nMajor", "alpha_fc", data=histValues, label="Alpha")
-axes[2].set_ylabel(r"$\alpha [^\circ]$", rotation="horizontal", ha="right", fontsize=24)
+            # Objective Optimality and Feasibility
+            axes[0].plot("nMajor", "optimality", data=histValues, label="Optimality")
+            axes[0].plot("nMajor", "feasibility", data=histValues, label="Feasibility")
+            axes[0].set_yscale("log")
+            axes[0].axhline(1e-4, linestyle="--", color="gray")
+            axes[0].annotate("Convergence Criteria", xy=(3, 9e-5), ha="left", va="top", fontsize=24, color="gray")
+            axes[0].legend(fontsize=20, labelcolor="linecolor", loc="upper right", frameon=False)
+            axes[0].autoscale(enable=True, tight=True)
 
-axes[3].plot("nMajor", "twist", data=histValues, label="Twist")
-axes[3].set_ylabel(r"Twist $[^\circ]$", rotation="horizontal", ha="right", fontsize=24)
+            # Objective (Drag Coefficient)
+            axes[1].plot("iter", "obj", data=histValues, label="Objective ($C_D$)")
+            axes[1].set_ylabel("Objective ($C_D$)", rotation="horizontal", ha="right", fontsize=24)
 
-axes[4].plot("nMajor", "cl_con_fc", data=histValues, label="cl_con")
-axes[4].set_ylabel("Lift constraint", rotation="horizontal", ha="right", fontsize=24)
+            # Angle of Attack
+            axes[2].plot("iter", "alpha_wing", data=histValues, label="Angle of Attack")
+            axes[2].set_ylabel(r"$\alpha$ [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
 
-for ax in axes:
-    ax.spines["right"].set_visible(False)
-    ax.spines["top"].set_visible(False)
+            # Wing Twist
+            axes[3].plot("iter", "twist", data=histValues, label="Wing Twist")
+            axes[3].set_ylabel("Twist [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
 
-    # Drop the rest of the spines
-    ax.spines["left"].set_position(("outward", 12))
-    ax.spines["bottom"].set_position(("outward", 12))
+            # Lift Constraint
+            axes[4].plot("iter", "cl_con_wing", data=histValues, label="Lift Constraint")
+            axes[4].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
 
-plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.png"))
+        else:
+
+            _, axes = plt.subplots(nrows=4, sharex=True, figsize=(10, 14))
+
+            # Objective (Drag Coefficient)
+
+            axes[0].plot("iter", "obj", data=histValues, label="Objective ($C_D$)")
+            axes[0].set_ylabel("Objective ($C_D$)", rotation="horizontal", ha="right", fontsize=24)
+
+            # Angle of Attack
+            axes[1].plot("iter", "alpha_wing", data=histValues, label="Angle of Attack")
+            axes[1].set_ylabel(r"$\alpha$ [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
+
+            # Wing Twist
+            axes[2].plot("iter", "twist", data=histValues, label="Wing Twist")
+            axes[2].set_ylabel("Twist [$^\circ$]", rotation="horizontal", ha="right", fontsize=24)
+
+            # Lift Constraint
+            axes[3].plot("iter", "cl_con_wing", data=histValues, label="Lift Constraint")
+            axes[3].set_ylabel("Lift Constraint", rotation="horizontal", ha="right", fontsize=24)
+
+        # Adjust subplot aesthetics
+        for ax in axes:
+            ax.spines["right"].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["left"].set_position(("outward", 12))
+            ax.spines["bottom"].set_position(("outward", 12))
+
+        plt.show()
+        plt.savefig(os.path.join(args.outputDir, "aero_wing_opt_hist.jpg"), bbox_inches = 'tight')
+    
+    except FileNotFoundError as fnf_error:
+        print(fnf_error)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
Update the plotting file for optimization history to cater for all the optimizers in the current version

## Description
- The plotting file only catered for SNOPT optimizer and would give errors when using SLSQP
- An issue was raised and a suggestion of a PR to correct this behavior
- Add a parser argument with opt option to check for optimizer and then run the code accordingly
- Added an if else statement to check which optimizer is being used
- The code would change the layout and number of the plots accordingly
- Added a try and except block to check whether an optimization history file exists or not

## Expected time until merged
The PR is not urgent as, but a week should be enough for review and merging.

## Type of change
What types of change is it?
Select the appropriate type(s) that describe this PR

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
run the code:

`python plot_optHist.py --histFile output/opt.hst --outputDir output/ --opt "SNOPT"`

try changing the --opt argument to either "SLSQP" or "IPOPT"

## Checklist

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
